### PR TITLE
添加 mingw-w64 支持

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,10 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - ubuntu-22.04-arm
+        host_arch:
+          - x86_64
+          - aarch64
+          - mingw-w64
         version:
           - legacy
           - stable
@@ -30,10 +33,10 @@ jobs:
       - name: Build
         run: |
           sudo rm -rf /opt/*
-          ./scripts/make ${{ matrix.target }} ${{ matrix.version }}
+          ./scripts/make ${{ matrix.target }} ${{ matrix.version }} ${{ matrix.host_arch }}
       - name: Generate file
         run: |
-          file_name="$(uname -m)-cross-tools-${{ matrix.target }}-${{ matrix.version }}"
+          file_name="$(uname -m)-cross-tools-${{ matrix.target }}-${{ matrix.version }}-${{ matrix.host_arch }}"
           echo "file_name=${file_name}" >> $GITHUB_ENV
           ls -al
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
           ./scripts/make ${{ matrix.target }} ${{ matrix.version }} ${{ matrix.host_arch }}
       - name: Generate file
         run: |
-          file_name="$(uname -m)-cross-tools-${{ matrix.target }}-${{ matrix.version }}-${{ matrix.host_arch }}"
+          file_name="${{ matrix.host_arch }}-cross-tools-${{ matrix.target }}-${{ matrix.version }}"
           echo "file_name=${file_name}" >> $GITHUB_ENV
           ls -al
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,9 @@ name: Release
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build
@@ -31,27 +34,23 @@ jobs:
         with:
           fetch-depth: 1
       - name: Build
+        id: build
         run: |
           sudo rm -rf /opt/*
           ./scripts/make ${{ matrix.target }} ${{ matrix.version }} ${{ matrix.host_arch }}
-      - name: Generate file
-        run: |
-          file_name="${{ matrix.host_arch }}-cross-tools-${{ matrix.target }}-${{ matrix.version }}"
-          echo "file_name=${file_name}" >> $GITHUB_ENV
-          ls -al
 
       - name: Upload package
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.file_name }}.tar.xz
-          path: ${{ env.file_name }}.tar.xz
+          name: ${{ steps.build.outputs.FILE_NAME }}.tar.xz
+          path: ${{ steps.build.outputs.FILE_NAME }}.tar.xz
           if-no-files-found: error
           retention-days: 1
       - name: Upload checksum
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.file_name }}.tar.xz.sha256
-          path: ${{ env.file_name }}.tar.xz.sha256
+          name: ${{ steps.build.outputs.FILE_NAME }}.tar.xz.sha256
+          path: ${{ steps.build.outputs.FILE_NAME }}.tar.xz.sha256
           if-no-files-found: error
           retention-days: 1
 

--- a/scripts/make
+++ b/scripts/make
@@ -19,12 +19,18 @@ GCC_PACKAGE=""
 case $HOST_ARCH in
     x86_64)
         GCC_PACKAGE="gcc g++"
+        HOST_CC="gcc"
+        HOST_CXX="g++"
         ;;
     aarch64)
         GCC_PACKAGE="gcc-aarch64-linux-gnu g++-aarch64-linux-gnu"
+        HOST_CC="aarch64-linux-gnu-gcc"
+        HOST_CXX="aarch64-linux-gnu-g++"
         ;;
     mingw-w64)
         GCC_PACKAGE="gcc-mingw-w64 g++-mingw-w64"
+        HOST_CC="x86_64-w64-mingw32-gcc-win32"
+        HOST_CXX="x86_64-w64-mingw32-g++-win32"
         ;;
     *)
         echo "Unsupported host architecture: ${HOST_ARCH}"
@@ -91,6 +97,8 @@ mkdir -p build
 cp targets/${TARGET}/${VERSION}/.config build/.config
 pushd build
 export CT_ALLOW_BUILD_AS_ROOT_SURE=1
+export CC="$HOST_CC"
+export CXX="$HOST_CXX"
 ct-ng build.2 || { tail -n 500 build.log; exit $ERRCODE; }
 popd
 

--- a/scripts/make
+++ b/scripts/make
@@ -96,8 +96,8 @@ sudo mkdir -p /opt
 sudo chmod 0777 /opt
 mkdir -p build
 cp targets/${TARGET}/${VERSION}/.config build/.config
-# Add CT_HOST to the config file
-echo "CT_HOST=\"${HOST_PREFIX}\"" | tee -a build/.config
+# Replace CT_HOST="" to real HOST_PREFIX
+sed -i "s/CT_HOST=\"\"/CT_HOST=\"${HOST_PREFIX}\"/g" build/.config
 pushd build
 export CT_ALLOW_BUILD_AS_ROOT_SURE=1
 ct-ng build.2 || { tail -n 500 build.log; exit $ERRCODE; }

--- a/scripts/make
+++ b/scripts/make
@@ -18,17 +18,20 @@ fi
 GCC_PACKAGE=""
 case $HOST_ARCH in
     x86_64)
-        GCC_PACKAGE="gcc g++"
+        GCC_PACKAGE="gcc"
+        GPP_PACKAGE="g++"
         HOST_CC="gcc"
         HOST_CXX="g++"
         ;;
     aarch64)
-        GCC_PACKAGE="gcc-aarch64-linux-gnu g++-aarch64-linux-gnu"
+        GCC_PACKAGE="gcc-aarch64-linux-gnu"
+        GPP_PACKAGE="g++-aarch64-linux-gnu"
         HOST_CC="aarch64-linux-gnu-gcc"
         HOST_CXX="aarch64-linux-gnu-g++"
         ;;
     mingw-w64)
-        GCC_PACKAGE="gcc-mingw-w64 g++-mingw-w64"
+        GCC_PACKAGE="gcc-mingw-w64"
+        GPP_PACKAGE="g++-mingw-w64"
         HOST_CC="x86_64-w64-mingw32-gcc-win32"
         HOST_CXX="x86_64-w64-mingw32-g++-win32"
         ;;
@@ -42,6 +45,7 @@ esac
 sudo apt-get update
 sudo apt-get install -y --no-install-recommends \
     "$GCC_PACKAGE" \
+    "$GPP_PACKAGE" \
     automake \
     bison \
     bzip2 \

--- a/scripts/make
+++ b/scripts/make
@@ -107,6 +107,6 @@ popd
 sudo mv /opt/x-tools/${TARGET} .
 sudo chown -R root:root ${TARGET}
 
-FILE_NAME="$(uname -m)-cross-tools-${TARGET}-${VERSION}"
+FILE_NAME="${HOST_ARCH}-cross-tools-${TARGET}-${VERSION}"
 sudo tar -cJf ${FILE_NAME}.tar.xz ${TARGET}
 sudo sha256sum ${FILE_NAME}.tar.xz | awk '{ print $1 }' > ${FILE_NAME}.tar.xz.sha256

--- a/scripts/make
+++ b/scripts/make
@@ -101,8 +101,7 @@ mkdir -p build
 cp targets/${TARGET}/${VERSION}/.config build/.config
 pushd build
 export CT_ALLOW_BUILD_AS_ROOT_SURE=1
-export CC="$HOST_CC"
-export CXX="$HOST_CXX"
+export CT_CC="$HOST_CC"
 ct-ng build.2 || { tail -n 500 build.log; exit $ERRCODE; }
 popd
 

--- a/scripts/make
+++ b/scripts/make
@@ -20,20 +20,17 @@ case $HOST_ARCH in
     x86_64)
         GCC_PACKAGE="gcc"
         GPP_PACKAGE="g++"
-        HOST_CC="gcc"
-        HOST_CXX="g++"
+        HOST_PREFIX="x86_64-linux-gnu"
         ;;
     aarch64)
         GCC_PACKAGE="gcc-aarch64-linux-gnu"
         GPP_PACKAGE="g++-aarch64-linux-gnu"
-        HOST_CC="aarch64-linux-gnu-gcc"
-        HOST_CXX="aarch64-linux-gnu-g++"
+        HOST_PREFIX="aarch64-linux-gnu"
         ;;
     mingw-w64)
-        GCC_PACKAGE="gcc-mingw-w64"
-        GPP_PACKAGE="g++-mingw-w64"
-        HOST_CC="x86_64-w64-mingw32-gcc-win32"
-        HOST_CXX="x86_64-w64-mingw32-g++-win32"
+        GCC_PACKAGE="gcc-mingw-w64-x86-64-win32"
+        GPP_PACKAGE="g++-mingw-w64-x86-64-win32"
+        HOST_PREFIX="x86_64-w64-mingw32"
         ;;
     *)
         echo "Unsupported host architecture: ${HOST_ARCH}"
@@ -99,9 +96,10 @@ sudo mkdir -p /opt
 sudo chmod 0777 /opt
 mkdir -p build
 cp targets/${TARGET}/${VERSION}/.config build/.config
+# Add CT_HOST to the config file
+echo "CT_HOST=\"${HOST_PREFIX}\"" | tee -a build/.config
 pushd build
 export CT_ALLOW_BUILD_AS_ROOT_SURE=1
-export CT_CC="$HOST_CC"
 ct-ng build.2 || { tail -n 500 build.log; exit $ERRCODE; }
 popd
 

--- a/scripts/make
+++ b/scripts/make
@@ -107,6 +107,7 @@ popd
 sudo mv /opt/x-tools/${TARGET} .
 sudo chown -R root:root ${TARGET}
 
-FILE_NAME="${HOST_ARCH}-cross-tools-${TARGET}-${VERSION}"
+FILE_NAME="${HOST_PREFIX}-cross-tools-${TARGET}-${VERSION}"
+echo "FILE_NAME=${FILE_NAME}" >> "$GITHUB_OUTPUT"
 sudo tar -cJf ${FILE_NAME}.tar.xz ${TARGET}
 sudo sha256sum ${FILE_NAME}.tar.xz | awk '{ print $1 }' > ${FILE_NAME}.tar.xz.sha256

--- a/scripts/make
+++ b/scripts/make
@@ -4,19 +4,38 @@ set -e
 
 TARGET=$1
 VERSION=$2
+HOST_ARCH=$3
 
 if [ -z "${VERSION}" ]; then
     VERSION=stable
 fi
 
-if [ -z "${TARGET}" ]; then
-    echo "Usage: $0 <target> <version>"
+if [ -z "${TARGET}" ] || [ -z "${HOST_ARCH}" ]; then
+    echo "Usage: $0 <target> <version> <host-arch>"
     exit 1
 fi
+
+GCC_PACKAGE=""
+case $HOST_ARCH in
+    x86_64)
+        GCC_PACKAGE="gcc g++"
+        ;;
+    aarch64)
+        GCC_PACKAGE="gcc-aarch64-linux-gnu g++-aarch64-linux-gnu"
+        ;;
+    mingw-w64)
+        GCC_PACKAGE="gcc-mingw-w64 g++-mingw-w64"
+        ;;
+    *)
+        echo "Unsupported host architecture: ${HOST_ARCH}"
+        exit 1
+        ;;
+esac
 
 # packages
 sudo apt-get update
 sudo apt-get install -y --no-install-recommends \
+    "$GCC_PACKAGE" \
     automake \
     bison \
     bzip2 \

--- a/targets/loongarch64-unknown-linux-gnu/latest/.config
+++ b/targets/loongarch64-unknown-linux-gnu/latest/.config
@@ -224,10 +224,10 @@ CT_TARGET_ALIAS=""
 # Toolchain type
 #
 # CT_NATIVE is not set
-CT_CROSS=y
+# CT_CROSS is not set
 # CT_CROSS_NATIVE is not set
-# CT_CANADIAN is not set
-CT_TOOLCHAIN_TYPE="cross"
+CT_CANADIAN=y
+CT_TOOLCHAIN_TYPE="canadian"
 
 #
 # Build system
@@ -235,6 +235,13 @@ CT_TOOLCHAIN_TYPE="cross"
 CT_BUILD=""
 CT_BUILD_PREFIX=""
 CT_BUILD_SUFFIX=""
+
+#
+# Host system
+#
+CT_HOST=""
+CT_HOST_PREFIX=""
+CT_HOST_SUFFIX=""
 
 #
 # Misc options

--- a/targets/loongarch64-unknown-linux-gnu/legacy/.config
+++ b/targets/loongarch64-unknown-linux-gnu/legacy/.config
@@ -223,10 +223,10 @@ CT_TARGET_ALIAS=""
 # Toolchain type
 #
 # CT_NATIVE is not set
-CT_CROSS=y
+# CT_CROSS is not set
 # CT_CROSS_NATIVE is not set
-# CT_CANADIAN is not set
-CT_TOOLCHAIN_TYPE="cross"
+CT_CANADIAN=y
+CT_TOOLCHAIN_TYPE="canadian"
 
 #
 # Build system
@@ -234,6 +234,13 @@ CT_TOOLCHAIN_TYPE="cross"
 CT_BUILD=""
 CT_BUILD_PREFIX=""
 CT_BUILD_SUFFIX=""
+
+#
+# Host system
+#
+CT_HOST=""
+CT_HOST_PREFIX=""
+CT_HOST_SUFFIX=""
 
 #
 # Misc options

--- a/targets/loongarch64-unknown-linux-gnu/mainline/.config
+++ b/targets/loongarch64-unknown-linux-gnu/mainline/.config
@@ -222,10 +222,10 @@ CT_TARGET_ALIAS=""
 # Toolchain type
 #
 # CT_NATIVE is not set
-CT_CROSS=y
+# CT_CROSS is not set
 # CT_CROSS_NATIVE is not set
-# CT_CANADIAN is not set
-CT_TOOLCHAIN_TYPE="cross"
+CT_CANADIAN=y
+CT_TOOLCHAIN_TYPE="canadian"
 
 #
 # Build system
@@ -233,6 +233,13 @@ CT_TOOLCHAIN_TYPE="cross"
 CT_BUILD=""
 CT_BUILD_PREFIX=""
 CT_BUILD_SUFFIX=""
+
+#
+# Host system
+#
+CT_HOST=""
+CT_HOST_PREFIX=""
+CT_HOST_SUFFIX=""
 
 #
 # Misc options

--- a/targets/loongarch64-unknown-linux-gnu/stable/.config
+++ b/targets/loongarch64-unknown-linux-gnu/stable/.config
@@ -223,10 +223,10 @@ CT_TARGET_ALIAS=""
 # Toolchain type
 #
 # CT_NATIVE is not set
-CT_CROSS=y
+# CT_CROSS is not set
 # CT_CROSS_NATIVE is not set
-# CT_CANADIAN is not set
-CT_TOOLCHAIN_TYPE="cross"
+CT_CANADIAN=y
+CT_TOOLCHAIN_TYPE="canadian"
 
 #
 # Build system
@@ -234,6 +234,13 @@ CT_TOOLCHAIN_TYPE="cross"
 CT_BUILD=""
 CT_BUILD_PREFIX=""
 CT_BUILD_SUFFIX=""
+
+#
+# Host system
+#
+CT_HOST=""
+CT_HOST_PREFIX=""
+CT_HOST_SUFFIX=""
 
 #
 # Misc options

--- a/targets/loongarch64-unknown-linux-musl/latest/.config
+++ b/targets/loongarch64-unknown-linux-musl/latest/.config
@@ -223,10 +223,10 @@ CT_TARGET_ALIAS=""
 # Toolchain type
 #
 # CT_NATIVE is not set
-CT_CROSS=y
+# CT_CROSS is not set
 # CT_CROSS_NATIVE is not set
-# CT_CANADIAN is not set
-CT_TOOLCHAIN_TYPE="cross"
+CT_CANADIAN=y
+CT_TOOLCHAIN_TYPE="canadian"
 
 #
 # Build system
@@ -234,6 +234,13 @@ CT_TOOLCHAIN_TYPE="cross"
 CT_BUILD=""
 CT_BUILD_PREFIX=""
 CT_BUILD_SUFFIX=""
+
+#
+# Host system
+#
+CT_HOST=""
+CT_HOST_PREFIX=""
+CT_HOST_SUFFIX=""
 
 #
 # Misc options

--- a/targets/loongarch64-unknown-linux-musl/legacy/.config
+++ b/targets/loongarch64-unknown-linux-musl/legacy/.config
@@ -223,10 +223,10 @@ CT_TARGET_ALIAS=""
 # Toolchain type
 #
 # CT_NATIVE is not set
-CT_CROSS=y
+# CT_CROSS is not set
 # CT_CROSS_NATIVE is not set
-# CT_CANADIAN is not set
-CT_TOOLCHAIN_TYPE="cross"
+CT_CANADIAN=y
+CT_TOOLCHAIN_TYPE="canadian"
 
 #
 # Build system
@@ -234,6 +234,13 @@ CT_TOOLCHAIN_TYPE="cross"
 CT_BUILD=""
 CT_BUILD_PREFIX=""
 CT_BUILD_SUFFIX=""
+
+#
+# Host system
+#
+CT_HOST=""
+CT_HOST_PREFIX=""
+CT_HOST_SUFFIX=""
 
 #
 # Misc options

--- a/targets/loongarch64-unknown-linux-musl/mainline/.config
+++ b/targets/loongarch64-unknown-linux-musl/mainline/.config
@@ -223,10 +223,10 @@ CT_TARGET_ALIAS=""
 # Toolchain type
 #
 # CT_NATIVE is not set
-CT_CROSS=y
+# CT_CROSS is not set
 # CT_CROSS_NATIVE is not set
-# CT_CANADIAN is not set
-CT_TOOLCHAIN_TYPE="cross"
+CT_CANADIAN=y
+CT_TOOLCHAIN_TYPE="canadian"
 
 #
 # Build system
@@ -234,6 +234,13 @@ CT_TOOLCHAIN_TYPE="cross"
 CT_BUILD=""
 CT_BUILD_PREFIX=""
 CT_BUILD_SUFFIX=""
+
+#
+# Host system
+#
+CT_HOST=""
+CT_HOST_PREFIX=""
+CT_HOST_SUFFIX=""
 
 #
 # Misc options

--- a/targets/loongarch64-unknown-linux-musl/stable/.config
+++ b/targets/loongarch64-unknown-linux-musl/stable/.config
@@ -223,10 +223,10 @@ CT_TARGET_ALIAS=""
 # Toolchain type
 #
 # CT_NATIVE is not set
-CT_CROSS=y
+# CT_CROSS is not set
 # CT_CROSS_NATIVE is not set
-# CT_CANADIAN is not set
-CT_TOOLCHAIN_TYPE="cross"
+CT_CANADIAN=y
+CT_TOOLCHAIN_TYPE="canadian"
 
 #
 # Build system
@@ -234,6 +234,13 @@ CT_TOOLCHAIN_TYPE="cross"
 CT_BUILD=""
 CT_BUILD_PREFIX=""
 CT_BUILD_SUFFIX=""
+
+#
+# Host system
+#
+CT_HOST=""
+CT_HOST_PREFIX=""
+CT_HOST_SUFFIX=""
 
 #
 # Misc options


### PR DESCRIPTION
如题，更改了构建脚本，使得crosstool-ng可以产出mingw-w64的工具链。

基于此，可以添加更多的host支持，如果有需求~

已知问题：
 - glibc版本的工具链暂时无法编译程序，提示缺少部分头文件，例如：
   ![2232376840e9de90c38cc31670fe129c](https://github.com/user-attachments/assets/647df3dd-2f92-45a3-be24-a586daed22be)
